### PR TITLE
Added support of symfony/serializer v4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "lexik/jwt-authentication-bundle": "^2.6",
         "gesdinet/jwt-refresh-token-bundle": "^0.8",
         "imagine/imagine": "^1.2",
-        "symfony/serializer": "^5.0",
+        "symfony/serializer": "^4.4 || ^5.0",
         "symfony/property-info": "^4.4"
     },
     "suggest": {


### PR DESCRIPTION
A lot of Sylius components have Symfony Serializer v4.4 as a dependency and that's why there is no ability to upgrade it to version 5